### PR TITLE
Feature/upgrade with cmdline

### DIFF
--- a/apt-private/private-install.h
+++ b/apt-private/private-install.h
@@ -14,6 +14,9 @@
 
 bool DoInstall(CommandLine &Cmd);
 
+bool DoCacheManipulationFromCommandLine(CommandLine &CmdL, CacheFile &Cache,
+                                        std::map<unsigned short, APT::VersionSet> &verset);
+bool DoCacheManipulationFromCommandLine(CommandLine &CmdL, CacheFile &Cache);
 
 bool InstallPackages(CacheFile &Cache,bool ShwKept,bool Ask = true,
                         bool Safety = true);

--- a/apt-private/private-upgrade.cc
+++ b/apt-private/private-upgrade.cc
@@ -13,9 +13,6 @@
    packages */
 bool DoUpgradeNoNewPackages(CommandLine &CmdL)
 {
-   if (CmdL.FileSize() != 1)
-      return _error->Error(_("The upgrade command takes no arguments"));
-
    CacheFile Cache;
    if (Cache.OpenForInstall() == false || Cache.CheckDeps() == false)
       return false;
@@ -26,6 +23,10 @@ bool DoUpgradeNoNewPackages(CommandLine &CmdL)
       ShowBroken(c1out,Cache,false);
       return _error->Error(_("Internal error, AllUpgrade broke stuff"));
    }
+
+   // parse additional cmdline pkg manipulation switches
+   if(!DoCacheManipulationFromCommandLine(CmdL, Cache))
+      return false;
    
    return InstallPackages(Cache,true);
 }
@@ -34,9 +35,6 @@ bool DoUpgradeNoNewPackages(CommandLine &CmdL)
 // DoSafeUpgrade - Upgrade all packages with install but not remove	/*{{{*/
 bool DoUpgradeWithAllowNewPackages(CommandLine &CmdL)
 {
-   if (CmdL.FileSize() != 1)
-      return _error->Error(_("The upgrade command takes no arguments"));
-
    CacheFile Cache;
    if (Cache.OpenForInstall() == false || Cache.CheckDeps() == false)
       return false;
@@ -47,6 +45,10 @@ bool DoUpgradeWithAllowNewPackages(CommandLine &CmdL)
       ShowBroken(c1out,Cache,false);
       return _error->Error(_("Internal error, AllUpgrade broke stuff"));
    }
+
+   // parse additional cmdline pkg manipulation switches
+   if(!DoCacheManipulationFromCommandLine(CmdL, Cache))
+      return false;
    
    return InstallPackages(Cache,true);
 }

--- a/cmdline/apt-get.cc
+++ b/cmdline/apt-get.cc
@@ -350,9 +350,6 @@ bool DoMarkAuto(CommandLine &CmdL)
 /* Intelligent upgrader that will install and remove packages at will */
 bool DoDistUpgrade(CommandLine &CmdL)
 {
-   if (CmdL.FileSize() != 1)
-      return _error->Error(_("The dist-upgrade command takes no arguments"));
-
    CacheFile Cache;
    if (Cache.OpenForInstall() == false || Cache.CheckDeps() == false)
       return false;
@@ -365,6 +362,10 @@ bool DoDistUpgrade(CommandLine &CmdL)
       return false;
    }
    
+   // parse additional cmdline pkg manipulation switches
+   if(!DoCacheManipulationFromCommandLine(CmdL, Cache))
+      return false;
+
    c0out << _("Done") << endl;
    
    return InstallPackages(Cache,true);


### PR DESCRIPTION
This branch adds support to parse additional package manipulation arguments in upgrade/dist-upgrade. So you can write: "sudo apt-get dist-upgrade xulrunner-17-".
